### PR TITLE
Fixed overlapping legend and plot in umap display.

### DIFF
--- a/bsoid_app/analysis_subroutines/analysis_utilities/visuals.py
+++ b/bsoid_app/analysis_subroutines/analysis_utilities/visuals.py
@@ -200,7 +200,7 @@ def plot_trajectory(limbs, labels, soft_assignments, t_range, ord1, ord2, c,
                     if labels[transitions[t]] == g and o == 0:
                         ax1.axvspan(transitions[t], transitions[t + 1], color=cmap[g], alpha=0.2, lw=0)
                         plt.text(transitions[t], np.max([proc_limb[ord1[i]].max() for i in range(len(ord1))]),
-                                 '{}'.format(g), fontsize=6)
+                                 '{}'.format(g), fontsize=5, horizontalalignment='center')
         ax1 = plt.gca()
         ax1.get_xaxis().set_visible(False)
         ax2 = plt.subplot(2, 1, 2)
@@ -214,6 +214,8 @@ def plot_trajectory(limbs, labels, soft_assignments, t_range, ord1, ord2, c,
                 for g in np.unique(soft_assignments):
                     if labels[transitions[t]] == g:
                         ax2.axvspan(transitions[t], transitions[t + 1], color=cmap[g], alpha=0.2, lw=0)
+                        plt.text(transitions[t], np.max([proc_limb[ord1[i]].max() for i in range(len(ord1))]),
+                                 '{}'.format(g), fontsize=5, horizontalalignment='center')
         ax2 = plt.gca()
         ax1.spines['top'].set_visible(False)
         ax1.spines['right'].set_visible(False)
@@ -225,8 +227,19 @@ def plot_trajectory(limbs, labels, soft_assignments, t_range, ord1, ord2, c,
         ax2.spines['left'].set_visible(True)
         plt.gca().invert_yaxis()
         ax2.set_xticks(range(0, len(labels), 40))
-        ax1.set_yticks(range(0, int(np.percentile(np.concatenate(limbs), 98)), 5))
-        ax2.set_yticks(range(0, int(np.percentile(np.concatenate(limbs), 98)), 5))
+        
+        y_ticks = np.linspace(0, int(np.percentile(np.concatenate(limbs), 98)), 10)
+        ax1.set_yticks(y_ticks)
+        ax2.set_yticks(y_ticks)
+        
+        ax1.tick_params(axis='y', which='major', labelsize=5)
+        ax2.tick_params(axis='y', which='major', labelsize=5)
+        
+        for label in ax2.get_xticklabels():
+            label.set_rotation(45)
+            label.set_horizontalalignment('right')
+        
+        
         if save:
             ax1.spines['left'].set_linewidth(4)
             ax2.spines['left'].set_linewidth(4)

--- a/bsoid_app/analysis_subroutines/directed_graph_analysis.py
+++ b/bsoid_app/analysis_subroutines/directed_graph_analysis.py
@@ -50,17 +50,24 @@ class directed_graph:
             graph = nx.from_numpy_matrix(self.transition_matrix_norm, create_using=nx.MultiDiGraph())
             node_position = nx.layout.spring_layout(graph, seed=0)
             edge_colors = [graph[u][v][0].get('weight') for u, v in graph.edges()]
-            nodes = nx.draw_networkx_nodes(graph, node_position, node_size=self.node_sizes,
-                                           node_color='blue')
+
+            nodes = nx.draw_networkx_nodes(graph, node_position, node_size=self.node_sizes, node_color='blue')
+
+            # Draw edges with curved lines
             edges = nx.draw_networkx_edges(graph, node_position, node_size=self.node_sizes, arrowstyle='->',
-                                           arrowsize=8, edge_color=edge_colors, edge_cmap=plt.cm.Blues, width=1.5)
-            label_pos = [node_position[i] + 0.005 for i in range(len(node_position))]
-            nx.draw_networkx_labels(graph, label_pos, font_size=10)
+                                           arrowsize=8, edge_color=edge_colors, edge_cmap=plt.cm.Blues, width=1.5,
+                                           connectionstyle='arc3,rad=0.2', alpha=0.7)
+
+            nx.draw_networkx_labels(graph, node_position, font_size=10)
+
+            # Add colorbar
             pc = mpl.collections.PatchCollection(edges, cmap=plt.cm.Blues)
             pc.set_array(edge_colors)
             plt.colorbar(pc)
+
             ax = plt.gca()
             ax.set_axis_off()
+
             st.pyplot(fig)
 
     def main(self):

--- a/bsoid_app/analysis_subroutines/machine_performance.py
+++ b/bsoid_app/analysis_subroutines/machine_performance.py
@@ -72,9 +72,15 @@ class performance:
                                       (8.5, 16), fig_format, out_path, save=True)
 
     def main(self):
-        try:
-            self.load_performance()
-        except:
-            self.cross_validate()
-            self.load_performance()
+        """
+        Allows the client to start K-fold cross-validation regardless
+        of whether there is performance data to be loaded (this allows
+        clients to run this multiple times which may overwrite previous results
+        if not explicitly saved).
+        
+        If there exists past performance data, the client can see the most
+        recent results (even if not explicitly saved to the device).
+        """
+        self.cross_validate() 
+        self.load_performance()
         self.show_accuracy_plot()

--- a/bsoid_app/bsoid_utilities/likelihoodprocessing.py
+++ b/bsoid_app/bsoid_utilities/likelihoodprocessing.py
@@ -72,7 +72,7 @@ def import_folders(base_path, folders: list, pose):
 
 
 def adp_filt(currdf: object, pose):
-    lIndex = []
+    lIndex = [] # likelihood
     xIndex = []
     yIndex = []
     currdf = np.array(currdf[1:])

--- a/bsoid_app/bsoid_utilities/visuals.py
+++ b/bsoid_app/bsoid_utilities/visuals.py
@@ -45,8 +45,16 @@ def plot_classes(data, assignments):
     ax.set_xlabel('Dim. 1')
     ax.set_ylabel('Dim. 2')
     ax.set_zlabel('Dim. 3')
-    plt.legend(ncol=3, markerscale=6)
-    return fig, plt
+    
+    # Create legend as seperate figure
+    legend_fig = plt.figure()
+    legend_ax = legend_fig.add_subplot(111)
+    legend_ax.axis('off') 
+    handles, labels = ax.get_legend_handles_labels()
+    legend_ax.legend(handles, labels, ncol=3, markerscale=6, loc = 'center left')
+    legend_fig.tight_layout()
+    
+    return fig, legend_fig, plt
 
 
 def plot_accuracy(scores):

--- a/bsoid_app/clustering.py
+++ b/bsoid_app/clustering.py
@@ -54,11 +54,12 @@ class cluster:
         st.write('Showing {}% data that were confidently assigned.'
                  ''.format(round(self.assignments[self.assignments >= 0].shape[0] /
                                  self.assignments.shape[0] * 100)))
-        fig1, plt1 = visuals.plot_classes(self.sampled_embeddings[self.assignments >= 0],
+        fig1, legend, plt1 = visuals.plot_classes(self.sampled_embeddings[self.assignments >= 0],
                                           self.assignments[self.assignments >= 0])
-        plt1.suptitle('HDBSCAN assignment')
+        fig1.suptitle("HDBSCAN Assignment", ha='center')
         col1, col2 = st.beta_columns([2, 2])
         col1.pyplot(fig1)
+        col2.pyplot(legend)
 
     def slider(self, min_=0.5, max_=1.0):
         st.markdown('The following slider allows you to tweak number of groups based on minimum size requirements.')

--- a/bsoid_app/extract_features.py
+++ b/bsoid_app/extract_features.py
@@ -39,10 +39,9 @@ class extract:
         fraction = st.number_input('Enter training input __fraction__ (do not change this value if you wish '
                                    'to generate the side-by-side video seen on our GitHub page):',
                                    min_value=0.1, max_value=1.0, value=1.0)
-        if fraction == 1.0:
-            self.train_size = data_size
-        else:
-            self.train_size = int(data_size * fraction)
+        
+        self.train_size = int(data_size * fraction)
+ 
         st.markdown('You have opted to train on a cumulative of **{} minutes** total. '
                     'If this does not sound right, the framerate might be wrong.'.format(self.train_size / 600))
 


### PR DESCRIPTION
Put the plot and legend next to each other instead of on top of one another.
This fixes an issue mentioned by @Sathyanesan-Lab in #80 (Not #80 itself)